### PR TITLE
이미지 기능 구현

### DIFF
--- a/src/main/java/dcom/nearbuybackend/api/domain/post/controller/AuctionPostController.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/controller/AuctionPostController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
 
 @Api(tags = {"Auction Post Controller"})
 @RestController
@@ -30,10 +32,11 @@ public class AuctionPostController {
 
     @ApiOperation(value = "경매 게시글 등록", notes = "[인증 필요] 경매 게시글 정보를 등록합니다.")
     @PostMapping
-    public ResponseEntity<Void> registerAuctionPost(HttpServletRequest httpServletRequest, @ApiParam(value = "경매 게시글 등록 정보", required = true) @RequestBody AuctionPostRequestDto.AuctionPostRegister auctionPost) {
-        auctionPostService.registerAuctionPost(httpServletRequest, auctionPost);
-
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Map<String, Integer>> registerAuctionPost(HttpServletRequest httpServletRequest, @ApiParam(value = "경매 게시글 등록 정보", required = true) @RequestBody AuctionPostRequestDto.AuctionPostRegister auctionPost) {
+        Integer id = auctionPostService.registerAuctionPost(httpServletRequest, auctionPost);
+        Map<String, Integer> data = new HashMap<>();
+        data.put("postId", id);
+        return ResponseEntity.ok().body(data);
     }
 
     @ApiOperation(value = "경매 게시글 등록", notes = "[인증 필요] 경매 게시글 정보를 수정합니다.")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/controller/ExchangePostController.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/controller/ExchangePostController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
 
 @Api(tags = {"Exchange Post Controller"})
 @RequestMapping("/api/post/exchange")
@@ -30,9 +32,11 @@ public class ExchangePostController {
 
     @ApiOperation(value = "교환 게시글 등록", notes = "[인증 필요] 교환 게시글 정보를 등록합니다.")
     @PostMapping
-    public ResponseEntity<Void> registerExchangePost(HttpServletRequest httpServletRequest, @ApiParam(value = "교환 게시글 등록 정보", required = true) @RequestBody ExchangePostRequestDto.ExchangePostRegister exchangePost){
-        exchangePostService.registerExchangePost(httpServletRequest, exchangePost);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Map<String, Integer>> registerExchangePost(HttpServletRequest httpServletRequest, @ApiParam(value = "교환 게시글 등록 정보", required = true) @RequestBody ExchangePostRequestDto.ExchangePostRegister exchangePost){
+        Integer id = exchangePostService.registerExchangePost(httpServletRequest, exchangePost);
+        Map<String, Integer> data = new HashMap<>();
+        data.put("postId", id);
+        return ResponseEntity.ok().body(data);
     }
 
     @ApiOperation(value = "교환 게시글 수정", notes = "[인증 필요] 교환 게시글 정보를 수정합니다.")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/controller/FreePostController.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/controller/FreePostController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
 
 @Api(tags = {"Free Post Controller"})
 @RequestMapping("/api/post/free")
@@ -32,11 +34,13 @@ public class FreePostController {
 
     @ApiOperation(value = "나눔 게시글 등록", notes = "[인증 필요] 나눔 게시글 정보를 등록합니다.")
     @PostMapping
-    public ResponseEntity<Void> registerFreePost(HttpServletRequest httpServletRequest,
-                                                 @ApiParam(value = "나눔 게시글 등록 정보", required = true) @RequestBody FreePostRequestDto.FreePostRegister freePost) {
+    public ResponseEntity<Map<String, Integer>> registerFreePost(HttpServletRequest httpServletRequest,
+                                                                 @ApiParam(value = "나눔 게시글 등록 정보", required = true) @RequestBody FreePostRequestDto.FreePostRegister freePost) {
 
-        freePostService.registerFreePost(httpServletRequest, freePost);
-        return ResponseEntity.ok().build();
+        Integer id = freePostService.registerFreePost(httpServletRequest, freePost);
+        Map<String, Integer> data = new HashMap<>();
+        data.put("postId", id);
+        return ResponseEntity.ok().body(data);
     }
 
     @ApiOperation(value = "나눔 게시글 수정", notes = "[인증 필요] 나눔 게시글 정보를 수정합니다.")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/controller/GroupPostController.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/controller/GroupPostController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
 
 @Api(tags = {"Group Post Controller"})
 @RequestMapping("/api/post/group")
@@ -33,11 +35,13 @@ public class GroupPostController {
 
     @ApiOperation(value = "공구 게시글 등록", notes = "[인증 필요] 공구 게시글 정보를 등록합니다.")
     @PostMapping
-    public ResponseEntity<Void> registerGroupPost(HttpServletRequest httpServletRequest,
-                                                  @ApiParam(value = "공구 게시글 등록 정보", required = true) @RequestBody GroupPostRequestDto.GroupPostRegister groupPost) {
+    public ResponseEntity<Map<String, Integer>> registerGroupPost(HttpServletRequest httpServletRequest,
+                                                                  @ApiParam(value = "공구 게시글 등록 정보", required = true) @RequestBody GroupPostRequestDto.GroupPostRegister groupPost) {
 
-        groupPostService.registerGroupPost(httpServletRequest, groupPost);
-        return ResponseEntity.ok().build();
+        Integer id = groupPostService.registerGroupPost(httpServletRequest, groupPost);
+        Map<String, Integer> data = new HashMap<>();
+        data.put("postId", id);
+        return ResponseEntity.ok().body(data);
     }
 
     @ApiOperation(value = "공구 게시글 수정", notes = "[인증 필요] 공구 게시글 정보를 수정합니다.")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/controller/SalePostController.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/controller/SalePostController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
 
 @Api(tags = {"Sale Post Controller"})
 @RestController
@@ -27,10 +29,11 @@ public class SalePostController {
 
     @ApiOperation(value = "판매 게시글 등록", notes = "[인증 필요]판매 게시글을 등록합니다.")
     @PostMapping
-    public ResponseEntity<Void> registerSalePost(HttpServletRequest httpServletRequest, @ApiParam(value = "판매 게시글 등록 정보", required = true) @RequestBody SalePostRequestDto.SalePostRegister post) {
-        salePostService.registerSalePost(httpServletRequest, post);
-
-        return ResponseEntity.status(HttpStatus.OK).build();
+    public ResponseEntity<Map<String, Integer>> registerSalePost(HttpServletRequest httpServletRequest, @ApiParam(value = "판매 게시글 등록 정보", required = true) @RequestBody SalePostRequestDto.SalePostRegister post) {
+        Integer id = salePostService.registerSalePost(httpServletRequest, post);
+        Map<String, Integer> data = new HashMap<>();
+        data.put("postId", id);
+        return ResponseEntity.ok().body(data);
     }
 
     @ApiOperation(value = "판매 게시글 수정", notes = "[인증 필요]판매 게시글을 수정합니다.")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/dto/AuctionPostRequestDto.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/dto/AuctionPostRequestDto.java
@@ -18,8 +18,6 @@ public class AuctionPostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 태그")
@@ -43,8 +41,6 @@ public class AuctionPostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 진행여부")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/dto/ExchangePostRequestDto.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/dto/ExchangePostRequestDto.java
@@ -18,8 +18,6 @@ public class ExchangePostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 태그")
@@ -40,8 +38,6 @@ public class ExchangePostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 진행여부")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/dto/FreePostRequestDto.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/dto/FreePostRequestDto.java
@@ -16,8 +16,6 @@ public class FreePostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 태그")
@@ -32,8 +30,6 @@ public class FreePostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 진행여부")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/dto/GroupPostRequestDto.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/dto/GroupPostRequestDto.java
@@ -16,8 +16,6 @@ public class GroupPostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 태그")
@@ -40,8 +38,6 @@ public class GroupPostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 진행여부")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/dto/SalePostRequestDto.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/dto/SalePostRequestDto.java
@@ -18,8 +18,6 @@ public class SalePostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 태그")
@@ -39,8 +37,6 @@ public class SalePostRequestDto {
         private String title;
         @ApiModelProperty(value = "게시글 내용")
         private String detail;
-        @ApiModelProperty(value = "게시글 이미지")
-        private List<String> image;
         @ApiModelProperty(value = "게시글 위치")
         private String location;
         @ApiModelProperty(value = "게시글 진행여부")

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/AuctionPostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/AuctionPostService.java
@@ -36,7 +36,7 @@ public class AuctionPostService {
     }
 
     // 경매 게시글 등록
-    public void registerAuctionPost(HttpServletRequest httpServletRequest, AuctionPostRequestDto.AuctionPostRegister post) {
+    public Integer registerAuctionPost(HttpServletRequest httpServletRequest, AuctionPostRequestDto.AuctionPostRegister post) {
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
         String tagString = getJoinByComma(post.getTag());
@@ -56,7 +56,7 @@ public class AuctionPostService {
         auctionPost.setTime(System.currentTimeMillis());
         auctionPost.setCurrentPrice(post.getStartPrice());
 
-        auctionPostRepository.save(auctionPost);
+        return auctionPostRepository.save(auctionPost).getId();
     }
 
     private static String getJoinByComma(List<String> list) {

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/AuctionPostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/AuctionPostService.java
@@ -39,7 +39,6 @@ public class AuctionPostService {
     public void registerAuctionPost(HttpServletRequest httpServletRequest, AuctionPostRequestDto.AuctionPostRegister post) {
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
-        String imageString = getJoinByComma(post.getImage());
         String tagString = getJoinByComma(post.getTag());
 
         AuctionPost auctionPost = new AuctionPost();
@@ -48,7 +47,6 @@ public class AuctionPostService {
         auctionPost.setTitle(post.getTitle());
         auctionPost.setWriter(user);
         auctionPost.setDetail(post.getDetail());
-        auctionPost.setImage(imageString);
         auctionPost.setLocation(post.getLocation());
         auctionPost.setTag(tagString);
         auctionPost.setStartPrice(post.getStartPrice());
@@ -73,13 +71,11 @@ public class AuctionPostService {
                 new ResponseStatusException(HttpStatus.NOT_FOUND, "해당하는 게시물이 없습니다."));
 
         if (user.equals(auctionPost.getWriter())) {
-            String imageString = getJoinByComma(post.getImage());
             String tagString = getJoinByComma(post.getTag());
 
             auctionPost.setTitle(post.getTitle());
             auctionPost.setWriter(user);
             auctionPost.setDetail(post.getDetail());
-            auctionPost.setImage(imageString);
             auctionPost.setLocation(post.getLocation());
             auctionPost.setOngoing(post.getOngoing());
             auctionPost.setTag(tagString);

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/ExchangePostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/ExchangePostService.java
@@ -34,7 +34,6 @@ public class ExchangePostService {
     public void registerExchangePost(HttpServletRequest httpServletRequest, ExchangePostRequestDto.ExchangePostRegister post){
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
-        String imageString = getJoinByComma(post.getImage());
         String tagString = getJoinByComma(post.getTag());
 
         ExchangePost exchangePost = new ExchangePost();
@@ -42,7 +41,6 @@ public class ExchangePostService {
         exchangePost.setTitle(post.getTitle());
         exchangePost.setWriter(user);
         exchangePost.setDetail(post.getDetail());
-        exchangePost.setImage(imageString);
         exchangePost.setTime(System.currentTimeMillis());
         exchangePost.setLocation(post.getLocation());
         exchangePost.setOngoing(true);
@@ -64,12 +62,10 @@ public class ExchangePostService {
         ExchangePost newExchangePost = exchangePostRepository.findById(id).orElseThrow(() ->
                 new ResponseStatusException(HttpStatus.NOT_FOUND, "해당하는 게시물이 없습니다."));
         if (user.equals(newExchangePost.getWriter())) {
-            String imageList = getJoinByComma(post.getImage());
             String tagList = getJoinByComma(post.getTag());
 
             newExchangePost.setTitle(post.getTitle());
             newExchangePost.setDetail(post.getDetail());
-            newExchangePost.setImage(imageList);
             newExchangePost.setLocation(post.getLocation());
             newExchangePost.setOngoing(post.getOngoing());
             newExchangePost.setTag(tagList);

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/ExchangePostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/ExchangePostService.java
@@ -31,7 +31,7 @@ public class ExchangePostService {
     }
 
     // 교환 게시글 등록
-    public void registerExchangePost(HttpServletRequest httpServletRequest, ExchangePostRequestDto.ExchangePostRegister post){
+    public Integer registerExchangePost(HttpServletRequest httpServletRequest, ExchangePostRequestDto.ExchangePostRegister post){
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
         String tagString = getJoinByComma(post.getTag());
@@ -47,8 +47,7 @@ public class ExchangePostService {
         exchangePost.setTag(tagString);
         exchangePost.setTarget(post.getTarget());
 
-        exchangePostRepository.save(exchangePost);
-
+        return exchangePostRepository.save(exchangePost).getId();
     }
 
     private static String getJoinByComma(List<String> list) {

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/FreePostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/FreePostService.java
@@ -44,7 +44,6 @@ public class FreePostService {
         freePost.setTitle(post.getTitle());
         freePost.setWriter(user);
         freePost.setDetail(post.getDetail());
-        freePost.setImage(getJoinByComma(post.getImage()));
         freePost.setTime(System.currentTimeMillis());
         freePost.setLocation(post.getLocation());
         freePost.setOngoing(true);
@@ -69,12 +68,10 @@ public class FreePostService {
                 new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 id의 게시글을 찾을 수 없습니다."));
 
         if (user.equals(freePost.getWriter())) {
-            String imageList = getJoinByComma(post.getImage());
             String tagList = getJoinByComma(post.getTag());
 
             freePost.setTitle(post.getTitle());
             freePost.setDetail(post.getDetail());
-            freePost.setImage(imageList);
             freePost.setLocation(post.getLocation());
             freePost.setOngoing(post.getOngoing());
             freePost.setTag(tagList);

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/FreePostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/FreePostService.java
@@ -35,7 +35,7 @@ public class FreePostService {
     /**
      * 나눔 게시글 등록
      */
-    public void registerFreePost(HttpServletRequest httpServletRequest, FreePostRequestDto.FreePostRegister post) {
+    public Integer registerFreePost(HttpServletRequest httpServletRequest, FreePostRequestDto.FreePostRegister post) {
 
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
@@ -49,7 +49,7 @@ public class FreePostService {
         freePost.setOngoing(true);
         freePost.setTag(getJoinByComma(post.getTag()));
 
-        freePostRepository.save(freePost);
+        return freePostRepository.save(freePost).getId();
     }
 
     private static String getJoinByComma(List<String> list) {

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/GroupPostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/GroupPostService.java
@@ -45,7 +45,7 @@ public class GroupPostService {
     /**
      * 공구 게시글 등록
      */
-    public void registerGroupPost(HttpServletRequest httpServletRequest, GroupPostRequestDto.GroupPostRegister post) {
+    public Integer registerGroupPost(HttpServletRequest httpServletRequest, GroupPostRequestDto.GroupPostRegister post) {
 
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
@@ -65,7 +65,7 @@ public class GroupPostService {
         groupPost.setDistribute(post.getDistribute());
         groupPost.setDay(post.getDay().stream().map(l -> Long.toString(l)).collect(Collectors.joining(",")));
 
-        groupPostRepository.save(groupPost);
+        return groupPostRepository.save(groupPost).getId();
     }
 
     private static String getJoinByComma(List<String> list) {

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/GroupPostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/GroupPostService.java
@@ -18,6 +18,7 @@ import org.springframework.web.server.ResponseStatusException;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -54,7 +55,6 @@ public class GroupPostService {
         groupPost.setTitle(post.getTitle());
         groupPost.setWriter(user);
         groupPost.setDetail(post.getDetail());
-        groupPost.setImage(getJoinByComma(post.getImage()));
         groupPost.setTime(System.currentTimeMillis());
         groupPost.setLocation(post.getLocation());
         groupPost.setOngoing(true);
@@ -85,12 +85,10 @@ public class GroupPostService {
         );
 
         if (user.equals(groupPost.getWriter())) {
-            String imageList = getJoinByComma(post.getImage());
             String tagList = getJoinByComma(post.getTag());
 
             groupPost.setTitle(post.getTitle());
             groupPost.setDetail(post.getDetail());
-            groupPost.setImage(imageList);
             groupPost.setLocation(post.getLocation());
             groupPost.setOngoing(post.getOngoing());
             groupPost.setTag(tagList);
@@ -119,7 +117,7 @@ public class GroupPostService {
         });
 
 
-        if (groupPost.getTotalPeople() == groupPost.getCurrentPeople())
+        if (Objects.equals(groupPost.getTotalPeople(), groupPost.getCurrentPeople()))
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"공구 인원이 꽉 찼습니다.");
         else
             groupPost.setCurrentPeople(groupPost.getCurrentPeople() + 1);

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/SalePostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/SalePostService.java
@@ -32,7 +32,6 @@ public class SalePostService {
     public void registerSalePost(HttpServletRequest httpServletRequest, SalePostRequestDto.SalePostRegister post) {
         User user =  tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
-        String imageString = StringUtils.join(post.getImage(),',');
         String tagString = StringUtils.join(post.getTag(),',');
 
         SalePost salePost = new SalePost();
@@ -41,7 +40,6 @@ public class SalePostService {
         salePost.setTitle(post.getTitle());
         salePost.setWriter(user);
         salePost.setDetail(post.getDetail());
-        salePost.setImage(imageString);
         salePost.setTime(System.currentTimeMillis());
         salePost.setLocation(post.getLocation());
         salePost.setOngoing(true);
@@ -55,7 +53,6 @@ public class SalePostService {
     public void modifySalePost(HttpServletRequest httpServletRequest, Integer id, SalePostRequestDto.SalePostModify post) {
         User user =  tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
-        String imageString = StringUtils.join(post.getImage(),',');
         String tagString = StringUtils.join(post.getTag(),',');
 
         SalePost salePost = salePostRepository.findById(id).orElseThrow(()->
@@ -64,7 +61,6 @@ public class SalePostService {
         if(user.equals(salePost.getWriter())) {
             salePost.setTitle(post.getTitle());
             salePost.setDetail(post.getDetail());
-            salePost.setImage(imageString);
             salePost.setLocation(post.getLocation());
             salePost.setOngoing(post.getOngoing());
             salePost.setTag(tagString);

--- a/src/main/java/dcom/nearbuybackend/api/domain/post/service/SalePostService.java
+++ b/src/main/java/dcom/nearbuybackend/api/domain/post/service/SalePostService.java
@@ -29,7 +29,7 @@ public class SalePostService {
     }
 
     // 판매 게시글 등록
-    public void registerSalePost(HttpServletRequest httpServletRequest, SalePostRequestDto.SalePostRegister post) {
+    public Integer registerSalePost(HttpServletRequest httpServletRequest, SalePostRequestDto.SalePostRegister post) {
         User user =  tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
 
         String tagString = StringUtils.join(post.getTag(),',');
@@ -46,7 +46,7 @@ public class SalePostService {
         salePost.setTag(tagString);
         salePost.setSalePrice(post.getSalePrice());
 
-        salePostRepository.save(salePost);
+        return salePostRepository.save(salePost).getId();
     }
 
     // 판매 게시글 수정

--- a/src/main/java/dcom/nearbuybackend/api/global/image/ImageController.java
+++ b/src/main/java/dcom/nearbuybackend/api/global/image/ImageController.java
@@ -1,0 +1,60 @@
+package dcom.nearbuybackend.api.global.image;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+@Api(tags = {"Image Controller"})
+@RestController
+@RequestMapping("/api/image")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @ApiOperation(value = "이미지 조회", notes = "이미지를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 500, message = "URL [...] cannot be resolved in the file system for checking its content length")
+    })
+    @ResponseBody
+    @GetMapping("/{path}/{filename}")
+    public Resource showImage(@PathVariable String path, @PathVariable String filename) throws MalformedURLException {
+        String absolutePath = new File("").getAbsolutePath();
+        return new UrlResource("file:" + absolutePath + "/image/" + path + "/" + filename);
+    }
+
+    @ApiOperation(value = "유저 이미지 업로드", notes = "[인증 필요] 유저의 이미지를 업로드합니다. 이미 업로드한 이미지가 있다면 교체됩니다. 이미지의 타입은 jpg, png, gif로 제한됩니다.")
+    @ApiResponses({
+            @ApiResponse(code = 400, message = "이미지가 비어있습니다."),
+            @ApiResponse(code = 415, message = "미디어 타입을 알 수 없습니다."),
+            @ApiResponse(code = 415, message = "jpg, png, gif만 업로드할 수 있습니다.")
+    })
+    @PostMapping("/user")
+    public ResponseEntity<Void> uploadUserImage(
+            HttpServletRequest httpServletRequest,
+            @ApiParam(value = "유저 이미지", required = true) @RequestParam MultipartFile image
+    ) throws IOException {
+        imageService.uploadUserImage(httpServletRequest, image);
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "유저 이미지 삭제", notes = "[인증 필요] 유저의 이미지를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "해당 유저는 이미지가 없습니다."),
+            @ApiResponse(code = 404, message = "해당 유저의 이미지 경로가 잘못되었습니다.")
+    })
+    @DeleteMapping("/user")
+    public ResponseEntity<Void> deleteUserImage(HttpServletRequest httpServletRequest) {
+        imageService.deleteUserImage(httpServletRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/dcom/nearbuybackend/api/global/image/ImageController.java
+++ b/src/main/java/dcom/nearbuybackend/api/global/image/ImageController.java
@@ -12,6 +12,9 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Api(tags = {"Image Controller"})
 @RestController
@@ -56,5 +59,43 @@ public class ImageController {
     public ResponseEntity<Void> deleteUserImage(HttpServletRequest httpServletRequest) {
         imageService.deleteUserImage(httpServletRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "포스트 이미지 업로드", notes = "[인증 필요] 포스트의 이미지를 업로드합니다. 이미지의 타입은 jpg, png, gif로 제한됩니다.")
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "해당 id의 게시글을 찾을 수 없습니다."),
+            @ApiResponse(code = 401, message = "게시물 접근 권한이 없습니다."),
+            @ApiResponse(code = 400, message = "이미지가 비어있습니다."),
+            @ApiResponse(code = 415, message = "미디어 타입을 알 수 없습니다."),
+            @ApiResponse(code = 415, message = "jpg, png, gif만 업로드할 수 있습니다.")
+    })
+    @PostMapping("/post")
+    public ResponseEntity<Map<String, Integer>> uploadPostImage(
+            HttpServletRequest httpServletRequest,
+            @ApiParam(value = "게시글 ID", required = true) @RequestParam Integer id,
+            @ApiParam(value = "포스트 이미지", required = true) @RequestParam List<MultipartFile> image
+    ) throws IOException {
+        imageService.uploadPostImage(httpServletRequest, id, image);
+        Map<String, Integer> data = new HashMap<>();
+        data.put("postId", id);
+        return ResponseEntity.ok().body(data);
+    }
+
+    @ApiOperation(value = "포스트 이미지 삭제", notes = "[인증 필요] 포스의 이미지를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "해당 id의 게시글을 찾을 수 없습니다."),
+            @ApiResponse(code = 401, message = "게시물 접근 권한이 없습니다."),
+            @ApiResponse(code = 400, message = "index가 범위를 벗어났습니다."),
+            @ApiResponse(code = 404, message = "저장된 이미지 경로가 잘못되었습니다.")
+    })
+    @DeleteMapping("/post")
+    public ResponseEntity<Void> deletePostImage(
+            HttpServletRequest httpServletRequest,
+            @ApiParam(value = "게시글 ID", required = true) @RequestParam Integer id,
+            @ApiParam(value = "삭제할 이미지의 index", required = true) @RequestBody ImageRequestDto.PostImageDelete body
+    ) {
+        imageService.deletePostImage(httpServletRequest, id, body.getIndex());
+        return ResponseEntity.ok().build();
+
     }
 }

--- a/src/main/java/dcom/nearbuybackend/api/global/image/ImageRequestDto.java
+++ b/src/main/java/dcom/nearbuybackend/api/global/image/ImageRequestDto.java
@@ -1,0 +1,18 @@
+package dcom.nearbuybackend.api.global.image;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public class ImageRequestDto {
+    @ApiModel(value = "게시글 이미지 삭제 정보")
+    @Getter
+    @Setter
+    public static class PostImageDelete {
+        @ApiModelProperty(value = "삭제할 이미지 인덱스")
+        private List<Integer> index;
+    }
+}

--- a/src/main/java/dcom/nearbuybackend/api/global/image/ImageService.java
+++ b/src/main/java/dcom/nearbuybackend/api/global/image/ImageService.java
@@ -1,0 +1,80 @@
+package dcom.nearbuybackend.api.global.image;
+
+import dcom.nearbuybackend.api.domain.user.User;
+import dcom.nearbuybackend.api.domain.user.repository.UserRepository;
+import dcom.nearbuybackend.api.global.security.config.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final UserRepository userRepository;
+
+    private final TokenService tokenService;
+
+    public void uploadUserImage(HttpServletRequest httpServletRequest, MultipartFile image) throws IOException {
+        User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
+
+        if (image.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지가 비어있습니다.");
+        }
+
+        String contentType = image.getContentType();
+        String fileExtension;
+
+        if (ObjectUtils.isEmpty(contentType)) {
+            throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "미디어 타입을 알 수 없습니다.");
+        }
+
+        if (contentType.contains("image/jpeg")) {
+            fileExtension = ".jpg";
+        } else if (contentType.contains("image/png")) {
+            fileExtension = ".png";
+        } else if (contentType.contains("image/gif")) {
+            fileExtension = ".gif";
+        } else {
+            throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "jpg, png, gif만 업로드할 수 있습니다.");
+        }
+
+        String absolutePath = new File("").getAbsolutePath() + "/image/";
+        String path = "user/" + user.getId() + fileExtension;
+
+        File file = new File(absolutePath + path);
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+        image.transferTo(file);
+
+        user.setImage(path);
+        userRepository.save(user);
+    }
+
+    public void deleteUserImage(HttpServletRequest httpServletRequest) {
+        User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
+
+        String path = user.getImage();
+        if (path == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 유저는 이미지가 없습니다.");
+        }
+
+        String absolutePath = new File("").getAbsolutePath() + "/image/";
+        File file = new File(absolutePath + path);
+        if (!file.exists()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 유저의 이미지 경로가 잘못되었습니다.");
+        }
+
+        file.delete();
+        user.setImage(null);
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/dcom/nearbuybackend/api/global/image/ImageService.java
+++ b/src/main/java/dcom/nearbuybackend/api/global/image/ImageService.java
@@ -1,5 +1,7 @@
 package dcom.nearbuybackend.api.global.image;
 
+import dcom.nearbuybackend.api.domain.post.Post;
+import dcom.nearbuybackend.api.domain.post.repository.PostRepository;
 import dcom.nearbuybackend.api.domain.user.User;
 import dcom.nearbuybackend.api.domain.user.repository.UserRepository;
 import dcom.nearbuybackend.api.global.security.config.TokenService;
@@ -13,14 +15,21 @@ import org.springframework.web.server.ResponseStatusException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
 
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
 
     private final TokenService tokenService;
+
+    private final String absolutePath = new File("").getAbsolutePath() + "/image/";
 
     public void uploadUserImage(HttpServletRequest httpServletRequest, MultipartFile image) throws IOException {
         User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
@@ -29,30 +38,10 @@ public class ImageService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지가 비어있습니다.");
         }
 
-        String contentType = image.getContentType();
-        String fileExtension;
-
-        if (ObjectUtils.isEmpty(contentType)) {
-            throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "미디어 타입을 알 수 없습니다.");
-        }
-
-        if (contentType.contains("image/jpeg")) {
-            fileExtension = ".jpg";
-        } else if (contentType.contains("image/png")) {
-            fileExtension = ".png";
-        } else if (contentType.contains("image/gif")) {
-            fileExtension = ".gif";
-        } else {
-            throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "jpg, png, gif만 업로드할 수 있습니다.");
-        }
-
-        String absolutePath = new File("").getAbsolutePath() + "/image/";
-        String path = "user/" + user.getId() + fileExtension;
+        String path = "user/" + user.getId() + getFileExtension(image);
 
         File file = new File(absolutePath + path);
-        if (!file.exists()) {
-            file.mkdirs();
-        }
+        file.mkdirs();
         image.transferTo(file);
 
         user.setImage(path);
@@ -67,7 +56,6 @@ public class ImageService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 유저는 이미지가 없습니다.");
         }
 
-        String absolutePath = new File("").getAbsolutePath() + "/image/";
         File file = new File(absolutePath + path);
         if (!file.exists()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 유저의 이미지 경로가 잘못되었습니다.");
@@ -76,5 +64,94 @@ public class ImageService {
         file.delete();
         user.setImage(null);
         userRepository.save(user);
+    }
+
+    public void uploadPostImage(HttpServletRequest httpServletRequest, Integer id, List<MultipartFile> images) throws IOException {
+        User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
+
+        Post post = postRepository.findById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 id의 게시글을 찾을 수 없습니다."));
+
+        if (!user.equals(post.getWriter())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "게시물 접근 권한이 없습니다.");
+        }
+        if (images.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지가 비어있습니다.");
+        }
+
+        List<String> existingImage = getPostImages(post);
+
+        for (MultipartFile image : images) {
+            String path = "post-" + post.getId() + "/" + System.currentTimeMillis() + '-' + System.nanoTime() + getFileExtension(image);
+
+            File file = new File(absolutePath + path);
+            file.mkdirs();
+            image.transferTo(file);
+
+            existingImage.add(path);
+        }
+        post.setImage(String.join(",", existingImage));
+        postRepository.save(post);
+    }
+
+    public void deletePostImage(HttpServletRequest httpServletRequest, Integer id, List<Integer> index) {
+        User user = tokenService.getUserByToken(tokenService.resolveToken(httpServletRequest));
+
+        Post post = postRepository.findById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 id의 게시글을 찾을 수 없습니다."));
+
+        if (!user.equals(post.getWriter())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "게시물 접근 권한이 없습니다.");
+        }
+
+        List<String> existingImage = getPostImages(post);
+
+        index.sort(Collections.reverseOrder());
+
+        for (int i : index) {
+            try {
+                File file = new File(absolutePath + existingImage.get(i));
+                if (!file.exists()) {
+                    throw new ResponseStatusException(HttpStatus.NOT_FOUND, "저장된 이미지 경로가 잘못되었습니다.");
+                }
+
+                file.delete();
+                existingImage.remove(i);
+            } catch (IndexOutOfBoundsException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "index가 범위를 벗어났습니다.");
+            }
+        }
+        String result = String.join(",", existingImage);
+        if (existingImage.isEmpty()) {
+            result = null;
+        }
+        post.setImage(result);
+        postRepository.save(post);
+    }
+
+    private List<String> getPostImages(Post post) {
+        if (post.getImage() == null) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(Arrays.asList(post.getImage().split(",")));
+    }
+
+    private String getFileExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+
+        if (ObjectUtils.isEmpty(contentType)) {
+            throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "미디어 타입을 알 수 없습니다.");
+        }
+
+        if (contentType.contains("image/jpeg")) {
+            return ".jpg";
+        }
+        if (contentType.contains("image/png")) {
+            return ".png";
+        }
+        if (contentType.contains("image/gif")) {
+            return ".gif";
+        }
+        throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "jpg, png, gif만 업로드할 수 있습니다.");
     }
 }


### PR DESCRIPTION
# 수정 사항
판매, 교환, 나눔, 경매, 공구 각 도메인마다

1. 게시글 등록시 생성된 게시글의 postId를 반환합니다. 프론트엔드에서 게시글이 생성된 뒤 해당 게시글의 id로 이미지 업로드 API를 호출하거나 게시글 조회 API를 호출하기 위함입니다.

2. 게시글 등록시 이미지를 입력받지 않습니다. 게시글이 등록된 이미지 업로드 API를 따로 호출하기 때문입니다. 따라서 RequestDto 및 Service에서 이미지 저장 로직을 삭제했습니다.

# 추가 사항

1. 이미지 보기 기능
2. 유저 이미지 업로드 기능
3. 유저 이미지 삭제 기능
4. 게시글 이미지 업로드 기능
5. 게시글 이미지 삭제 기능